### PR TITLE
Use inline ImmutableDict

### DIFF
--- a/benchmark/benchmarks.jl
+++ b/benchmark/benchmarks.jl
@@ -30,10 +30,9 @@ SUITE["BASIC"]["scoped with assignment"] = @benchmarkable scoped(emptyf, svar =>
 SUITE["BASIC"]["scoped with assignment & ref"] = @benchmarkable scoped(()->svar[], svar => 2)
 
 function setup_scope(N)
-    scope = ScopedValues.Scope(nothing)
+    scope = nothing
     for i in 1:N
-        scope = ScopedValues.Scope(scope)
-        @atomic scope.values = ScopedValues.ImmutableDict{ScopedValue, Any}(depth, i)
+        scope = ScopedValues.Scope(scope, depth, i)
     end
 
     current_task().logstate = Base.CoreLogging.LogState(ScopedValues.ScopePayloadLogger(

--- a/perf.md
+++ b/perf.md
@@ -1,7 +1,7 @@
 # Benchmark Report for */home/vchuravy/src/ScopedVariables*
 
 ## Job Properties
-* Time of benchmark: 18 Aug 2023 - 11:29
+* Time of benchmark: 18 Aug 2023 - 11:46
 * Package commit: dirty
 * Julia commit: 661654
 * Julia command flags: None
@@ -17,106 +17,106 @@ An empty cell means that the value was zero.
 
 | ID                                          | time            | GC time | memory         | allocations |
 |---------------------------------------------|----------------:|--------:|---------------:|------------:|
-| `["BASIC", "scoped with assignment & ref"]` | 107.314 ns (5%) |         | 112 bytes (1%) |           4 |
-| `["BASIC", "scoped with assignment"]`       |  66.095 ns (5%) |         | 112 bytes (1%) |           4 |
+| `["BASIC", "scoped with assignment & ref"]` |  81.985 ns (5%) |         | 112 bytes (1%) |           4 |
+| `["BASIC", "scoped with assignment"]`       |  73.731 ns (5%) |         | 112 bytes (1%) |           4 |
 | `["BASIC", "scoped"]`                       |   1.249 ns (5%) |         |                |             |
-| `["BASIC", "unscoped"]`                     | 341.560 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=1"]`              |  22.269 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=10"]`             | 198.036 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=11"]`             | 213.926 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=12"]`             | 231.682 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=13"]`             | 249.751 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=14"]`             | 267.796 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=15"]`             | 288.529 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=16"]`             | 304.297 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=17"]`             | 324.035 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=18"]`             | 341.659 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=19"]`             | 362.596 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=2"]`              |  41.937 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=20"]`             | 379.412 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=21"]`             | 397.500 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=22"]`             | 416.533 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=23"]`             | 435.000 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=24"]`             | 451.726 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=25"]`             | 473.214 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=26"]`             | 490.821 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=27"]`             | 507.979 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=28"]`             | 538.737 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=29"]`             | 547.540 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=3"]`              |  61.059 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=30"]`             | 564.486 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=31"]`             | 582.762 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=32"]`             | 601.243 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=4"]`              |  87.024 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=5"]`              | 104.568 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=6"]`              | 121.517 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=7"]`              | 141.802 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=8"]`              | 159.298 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=9"]`              | 177.915 ns (5%) |         |                |             |
-| `["DEPTH", "emtpyf, depth=1"]`              |  88.855 ns (5%) |         | 128 bytes (1%) |           5 |
-| `["DEPTH", "emtpyf, depth=10"]`             | 935.000 ns (5%) |         |  1.25 KiB (1%) |          50 |
-| `["DEPTH", "emtpyf, depth=11"]`             |   1.104 μs (5%) |         |  1.38 KiB (1%) |          55 |
-| `["DEPTH", "emtpyf, depth=12"]`             |   1.180 μs (5%) |         |  1.50 KiB (1%) |          60 |
-| `["DEPTH", "emtpyf, depth=13"]`             |   1.278 μs (5%) |         |  1.62 KiB (1%) |          65 |
-| `["DEPTH", "emtpyf, depth=14"]`             |   1.364 μs (5%) |         |  1.75 KiB (1%) |          70 |
-| `["DEPTH", "emtpyf, depth=15"]`             |   1.509 μs (5%) |         |  1.88 KiB (1%) |          75 |
-| `["DEPTH", "emtpyf, depth=16"]`             |   1.561 μs (5%) |         |  2.00 KiB (1%) |          80 |
-| `["DEPTH", "emtpyf, depth=17"]`             |   1.715 μs (5%) |         |  2.12 KiB (1%) |          85 |
-| `["DEPTH", "emtpyf, depth=18"]`             |   1.844 μs (5%) |         |  2.25 KiB (1%) |          90 |
-| `["DEPTH", "emtpyf, depth=19"]`             |   1.987 μs (5%) |         |  2.38 KiB (1%) |          95 |
-| `["DEPTH", "emtpyf, depth=2"]`              | 160.050 ns (5%) |         | 256 bytes (1%) |          10 |
-| `["DEPTH", "emtpyf, depth=20"]`             |   2.001 μs (5%) |         |  2.50 KiB (1%) |         100 |
-| `["DEPTH", "emtpyf, depth=21"]`             |   2.172 μs (5%) |         |  2.62 KiB (1%) |         105 |
-| `["DEPTH", "emtpyf, depth=22"]`             |   2.259 μs (5%) |         |  2.75 KiB (1%) |         110 |
-| `["DEPTH", "emtpyf, depth=23"]`             |   2.257 μs (5%) |         |  2.88 KiB (1%) |         115 |
-| `["DEPTH", "emtpyf, depth=24"]`             |   2.474 μs (5%) |         |  3.00 KiB (1%) |         120 |
-| `["DEPTH", "emtpyf, depth=25"]`             |   2.629 μs (5%) |         |  3.12 KiB (1%) |         125 |
-| `["DEPTH", "emtpyf, depth=26"]`             |   2.668 μs (5%) |         |  3.25 KiB (1%) |         130 |
-| `["DEPTH", "emtpyf, depth=27"]`             |   2.842 μs (5%) |         |  3.38 KiB (1%) |         135 |
-| `["DEPTH", "emtpyf, depth=28"]`             |   2.942 μs (5%) |         |  3.50 KiB (1%) |         140 |
-| `["DEPTH", "emtpyf, depth=29"]`             |   3.269 μs (5%) |         |  3.62 KiB (1%) |         145 |
-| `["DEPTH", "emtpyf, depth=3"]`              | 230.896 ns (5%) |         | 384 bytes (1%) |          15 |
-| `["DEPTH", "emtpyf, depth=30"]`             |   3.123 μs (5%) |         |  3.75 KiB (1%) |         150 |
-| `["DEPTH", "emtpyf, depth=31"]`             |   3.251 μs (5%) |         |  3.88 KiB (1%) |         155 |
-| `["DEPTH", "emtpyf, depth=32"]`             |   3.665 μs (5%) |         |  4.00 KiB (1%) |         160 |
-| `["DEPTH", "emtpyf, depth=4"]`              | 366.425 ns (5%) |         | 512 bytes (1%) |          20 |
-| `["DEPTH", "emtpyf, depth=5"]`              | 442.615 ns (5%) |         | 640 bytes (1%) |          25 |
-| `["DEPTH", "emtpyf, depth=6"]`              | 530.778 ns (5%) |         | 768 bytes (1%) |          30 |
-| `["DEPTH", "emtpyf, depth=7"]`              | 669.887 ns (5%) |         | 896 bytes (1%) |          35 |
-| `["DEPTH", "emtpyf, depth=8"]`              | 760.588 ns (5%) |         |  1.00 KiB (1%) |          40 |
-| `["DEPTH", "emtpyf, depth=9"]`              | 858.276 ns (5%) |         |  1.12 KiB (1%) |          45 |
-| `["DEPTH", "scope + access, depth=1"]`      | 681.169 ns (5%) |         | 128 bytes (1%) |           5 |
-| `["DEPTH", "scope + access, depth=10"]`     |   1.375 μs (5%) |         |  1.25 KiB (1%) |          50 |
-| `["DEPTH", "scope + access, depth=11"]`     |   2.000 μs (5%) |         |  1.38 KiB (1%) |          55 |
-| `["DEPTH", "scope + access, depth=12"]`     |   1.962 μs (5%) |         |  1.50 KiB (1%) |          60 |
-| `["DEPTH", "scope + access, depth=13"]`     |   1.865 μs (5%) |         |  1.62 KiB (1%) |          65 |
-| `["DEPTH", "scope + access, depth=14"]`     |   2.313 μs (5%) |         |  1.75 KiB (1%) |          70 |
-| `["DEPTH", "scope + access, depth=15"]`     |   2.004 μs (5%) |         |  1.88 KiB (1%) |          75 |
-| `["DEPTH", "scope + access, depth=16"]`     |   2.449 μs (5%) |         |  2.00 KiB (1%) |          80 |
-| `["DEPTH", "scope + access, depth=17"]`     |   2.437 μs (5%) |         |  2.12 KiB (1%) |          85 |
-| `["DEPTH", "scope + access, depth=18"]`     |   2.461 μs (5%) |         |  2.25 KiB (1%) |          90 |
-| `["DEPTH", "scope + access, depth=19"]`     |   2.944 μs (5%) |         |  2.38 KiB (1%) |          95 |
-| `["DEPTH", "scope + access, depth=2"]`      | 413.950 ns (5%) |         | 256 bytes (1%) |          10 |
-| `["DEPTH", "scope + access, depth=20"]`     |   2.907 μs (5%) |         |  2.50 KiB (1%) |         100 |
-| `["DEPTH", "scope + access, depth=21"]`     |   3.236 μs (5%) |         |  2.62 KiB (1%) |         105 |
-| `["DEPTH", "scope + access, depth=22"]`     |   2.902 μs (5%) |         |  2.75 KiB (1%) |         110 |
-| `["DEPTH", "scope + access, depth=23"]`     |   3.200 μs (5%) |         |  2.88 KiB (1%) |         115 |
-| `["DEPTH", "scope + access, depth=24"]`     |   3.261 μs (5%) |         |  3.00 KiB (1%) |         120 |
-| `["DEPTH", "scope + access, depth=25"]`     |   3.382 μs (5%) |         |  3.12 KiB (1%) |         125 |
-| `["DEPTH", "scope + access, depth=26"]`     |   3.799 μs (5%) |         |  3.25 KiB (1%) |         130 |
-| `["DEPTH", "scope + access, depth=27"]`     |   3.989 μs (5%) |         |  3.38 KiB (1%) |         135 |
-| `["DEPTH", "scope + access, depth=28"]`     |   4.524 μs (5%) |         |  3.50 KiB (1%) |         140 |
-| `["DEPTH", "scope + access, depth=29"]`     |   4.399 μs (5%) |         |  3.62 KiB (1%) |         145 |
-| `["DEPTH", "scope + access, depth=3"]`      | 823.976 ns (5%) |         | 384 bytes (1%) |          15 |
-| `["DEPTH", "scope + access, depth=30"]`     |   4.330 μs (5%) |         |  3.75 KiB (1%) |         150 |
-| `["DEPTH", "scope + access, depth=31"]`     |   4.294 μs (5%) |         |  3.88 KiB (1%) |         155 |
-| `["DEPTH", "scope + access, depth=32"]`     |   4.607 μs (5%) |         |  4.00 KiB (1%) |         160 |
-| `["DEPTH", "scope + access, depth=4"]`      | 625.183 ns (5%) |         | 512 bytes (1%) |          20 |
-| `["DEPTH", "scope + access, depth=5"]`      |   1.180 μs (5%) |         | 640 bytes (1%) |          25 |
-| `["DEPTH", "scope + access, depth=6"]`      |   1.292 μs (5%) |         | 768 bytes (1%) |          30 |
-| `["DEPTH", "scope + access, depth=7"]`      |   1.303 μs (5%) |         | 896 bytes (1%) |          35 |
-| `["DEPTH", "scope + access, depth=8"]`      |   1.198 μs (5%) |         |  1.00 KiB (1%) |          40 |
-| `["DEPTH", "scope + access, depth=9"]`      |   1.278 μs (5%) |         |  1.12 KiB (1%) |          45 |
+| `["BASIC", "unscoped"]`                     |   2.980 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=1"]`              |   2.981 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=10"]`             |   7.013 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=11"]`             |   7.750 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=12"]`             |   8.206 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=13"]`             |   8.729 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=14"]`             |   9.677 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=15"]`             |  10.180 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=16"]`             |  10.683 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=17"]`             |  11.491 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=18"]`             |  12.627 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=19"]`             |  13.409 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=2"]`              |   3.723 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=20"]`             |  14.412 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=21"]`             |  15.200 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=22"]`             |  16.382 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=23"]`             |  17.172 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=24"]`             |  18.127 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=25"]`             |  19.128 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=26"]`             |  20.103 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=27"]`             |  21.088 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=28"]`             |  22.105 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=29"]`             |  23.316 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=3"]`              |   3.971 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=30"]`             |  24.054 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=31"]`             |  25.028 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=32"]`             |  26.045 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=4"]`              |   3.964 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=5"]`              |   3.970 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=6"]`              |   4.474 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=7"]`              |   4.971 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=8"]`              |   5.700 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=9"]`              |   6.452 ns (5%) |         |                |             |
+| `["DEPTH", "emtpyf, depth=1"]`              |  80.947 ns (5%) |         | 128 bytes (1%) |           5 |
+| `["DEPTH", "emtpyf, depth=10"]`             | 988.000 ns (5%) |         |  1.25 KiB (1%) |          50 |
+| `["DEPTH", "emtpyf, depth=11"]`             |   1.065 μs (5%) |         |  1.38 KiB (1%) |          55 |
+| `["DEPTH", "emtpyf, depth=12"]`             |   1.169 μs (5%) |         |  1.50 KiB (1%) |          60 |
+| `["DEPTH", "emtpyf, depth=13"]`             |   1.318 μs (5%) |         |  1.62 KiB (1%) |          65 |
+| `["DEPTH", "emtpyf, depth=14"]`             |   1.426 μs (5%) |         |  1.75 KiB (1%) |          70 |
+| `["DEPTH", "emtpyf, depth=15"]`             |   1.496 μs (5%) |         |  1.88 KiB (1%) |          75 |
+| `["DEPTH", "emtpyf, depth=16"]`             |   1.654 μs (5%) |         |  2.00 KiB (1%) |          80 |
+| `["DEPTH", "emtpyf, depth=17"]`             |   1.703 μs (5%) |         |  2.12 KiB (1%) |          85 |
+| `["DEPTH", "emtpyf, depth=18"]`             |   1.806 μs (5%) |         |  2.25 KiB (1%) |          90 |
+| `["DEPTH", "emtpyf, depth=19"]`             |   1.934 μs (5%) |         |  2.38 KiB (1%) |          95 |
+| `["DEPTH", "emtpyf, depth=2"]`              | 156.539 ns (5%) |         | 256 bytes (1%) |          10 |
+| `["DEPTH", "emtpyf, depth=20"]`             |   2.118 μs (5%) |         |  2.50 KiB (1%) |         100 |
+| `["DEPTH", "emtpyf, depth=21"]`             |   2.136 μs (5%) |         |  2.62 KiB (1%) |         105 |
+| `["DEPTH", "emtpyf, depth=22"]`             |   2.208 μs (5%) |         |  2.75 KiB (1%) |         110 |
+| `["DEPTH", "emtpyf, depth=23"]`             |   2.430 μs (5%) |         |  2.88 KiB (1%) |         115 |
+| `["DEPTH", "emtpyf, depth=24"]`             |   2.466 μs (5%) |         |  3.00 KiB (1%) |         120 |
+| `["DEPTH", "emtpyf, depth=25"]`             |   2.553 μs (5%) |         |  3.12 KiB (1%) |         125 |
+| `["DEPTH", "emtpyf, depth=26"]`             |   2.800 μs (5%) |         |  3.25 KiB (1%) |         130 |
+| `["DEPTH", "emtpyf, depth=27"]`             |   2.827 μs (5%) |         |  3.38 KiB (1%) |         135 |
+| `["DEPTH", "emtpyf, depth=28"]`             |   2.991 μs (5%) |         |  3.50 KiB (1%) |         140 |
+| `["DEPTH", "emtpyf, depth=29"]`             |   3.109 μs (5%) |         |  3.62 KiB (1%) |         145 |
+| `["DEPTH", "emtpyf, depth=3"]`              | 224.435 ns (5%) |         | 384 bytes (1%) |          15 |
+| `["DEPTH", "emtpyf, depth=30"]`             |   3.149 μs (5%) |         |  3.75 KiB (1%) |         150 |
+| `["DEPTH", "emtpyf, depth=31"]`             |   3.416 μs (5%) |         |  3.88 KiB (1%) |         155 |
+| `["DEPTH", "emtpyf, depth=32"]`             |   3.490 μs (5%) |         |  4.00 KiB (1%) |         160 |
+| `["DEPTH", "emtpyf, depth=4"]`              | 329.633 ns (5%) |         | 512 bytes (1%) |          20 |
+| `["DEPTH", "emtpyf, depth=5"]`              | 444.354 ns (5%) |         | 640 bytes (1%) |          25 |
+| `["DEPTH", "emtpyf, depth=6"]`              | 554.111 ns (5%) |         | 768 bytes (1%) |          30 |
+| `["DEPTH", "emtpyf, depth=7"]`              | 640.536 ns (5%) |         | 896 bytes (1%) |          35 |
+| `["DEPTH", "emtpyf, depth=8"]`              | 755.546 ns (5%) |         |  1.00 KiB (1%) |          40 |
+| `["DEPTH", "emtpyf, depth=9"]`              | 856.552 ns (5%) |         |  1.12 KiB (1%) |          45 |
+| `["DEPTH", "scope + access, depth=1"]`      | 105.195 ns (5%) |         | 128 bytes (1%) |           5 |
+| `["DEPTH", "scope + access, depth=10"]`     |   1.037 μs (5%) |         |  1.25 KiB (1%) |          50 |
+| `["DEPTH", "scope + access, depth=11"]`     |   1.217 μs (5%) |         |  1.38 KiB (1%) |          55 |
+| `["DEPTH", "scope + access, depth=12"]`     |   1.284 μs (5%) |         |  1.50 KiB (1%) |          60 |
+| `["DEPTH", "scope + access, depth=13"]`     |   1.382 μs (5%) |         |  1.62 KiB (1%) |          65 |
+| `["DEPTH", "scope + access, depth=14"]`     |   1.674 μs (5%) |         |  1.75 KiB (1%) |          70 |
+| `["DEPTH", "scope + access, depth=15"]`     |   1.595 μs (5%) |         |  1.88 KiB (1%) |          75 |
+| `["DEPTH", "scope + access, depth=16"]`     |   1.744 μs (5%) |         |  2.00 KiB (1%) |          80 |
+| `["DEPTH", "scope + access, depth=17"]`     |   1.822 μs (5%) |         |  2.12 KiB (1%) |          85 |
+| `["DEPTH", "scope + access, depth=18"]`     |   1.978 μs (5%) |         |  2.25 KiB (1%) |          90 |
+| `["DEPTH", "scope + access, depth=19"]`     |   2.129 μs (5%) |         |  2.38 KiB (1%) |          95 |
+| `["DEPTH", "scope + access, depth=2"]`      | 171.300 ns (5%) |         | 256 bytes (1%) |          10 |
+| `["DEPTH", "scope + access, depth=20"]`     |   2.267 μs (5%) |         |  2.50 KiB (1%) |         100 |
+| `["DEPTH", "scope + access, depth=21"]`     |   2.405 μs (5%) |         |  2.62 KiB (1%) |         105 |
+| `["DEPTH", "scope + access, depth=22"]`     |   2.596 μs (5%) |         |  2.75 KiB (1%) |         110 |
+| `["DEPTH", "scope + access, depth=23"]`     |   2.585 μs (5%) |         |  2.88 KiB (1%) |         115 |
+| `["DEPTH", "scope + access, depth=24"]`     |   2.743 μs (5%) |         |  3.00 KiB (1%) |         120 |
+| `["DEPTH", "scope + access, depth=25"]`     |   2.815 μs (5%) |         |  3.12 KiB (1%) |         125 |
+| `["DEPTH", "scope + access, depth=26"]`     |   2.830 μs (5%) |         |  3.25 KiB (1%) |         130 |
+| `["DEPTH", "scope + access, depth=27"]`     |   2.965 μs (5%) |         |  3.38 KiB (1%) |         135 |
+| `["DEPTH", "scope + access, depth=28"]`     |   3.236 μs (5%) |         |  3.50 KiB (1%) |         140 |
+| `["DEPTH", "scope + access, depth=29"]`     |   3.400 μs (5%) |         |  3.62 KiB (1%) |         145 |
+| `["DEPTH", "scope + access, depth=3"]`      | 257.711 ns (5%) |         | 384 bytes (1%) |          15 |
+| `["DEPTH", "scope + access, depth=30"]`     |   3.619 μs (5%) |         |  3.75 KiB (1%) |         150 |
+| `["DEPTH", "scope + access, depth=31"]`     |   3.411 μs (5%) |         |  3.88 KiB (1%) |         155 |
+| `["DEPTH", "scope + access, depth=32"]`     |   3.600 μs (5%) |         |  4.00 KiB (1%) |         160 |
+| `["DEPTH", "scope + access, depth=4"]`      | 370.732 ns (5%) |         | 512 bytes (1%) |          20 |
+| `["DEPTH", "scope + access, depth=5"]`      | 499.000 ns (5%) |         | 640 bytes (1%) |          25 |
+| `["DEPTH", "scope + access, depth=6"]`      | 587.000 ns (5%) |         | 768 bytes (1%) |          30 |
+| `["DEPTH", "scope + access, depth=7"]`      | 714.000 ns (5%) |         | 896 bytes (1%) |          35 |
+| `["DEPTH", "scope + access, depth=8"]`      | 803.000 ns (5%) |         |  1.00 KiB (1%) |          40 |
+| `["DEPTH", "scope + access, depth=9"]`      | 942.000 ns (5%) |         |  1.12 KiB (1%) |          45 |
 
 ## Benchmark Group List
 Here's a list of all the benchmark groups executed by this job:
@@ -134,10 +134,10 @@ Platform Info:
   uname: Linux 6.3.2-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 11 May 2023 16:40:42 +0000 x86_64 unknown
   CPU: AMD Ryzen 7 3700X 8-Core Processor: 
                  speed         user         nice          sys         idle          irq
-       #1-16  4051 MHz    1082294 s        282 s      41334 s   20869973 s       9692 s
-  Memory: 125.69889831542969 GB (111007.203125 MB free)
-  Uptime: 142505.67 sec
-  Load Avg:  2.18  1.97  1.71
+       #1-16  4050 MHz    1096215 s        282 s      42091 s   21012008 s       9766 s
+  Memory: 125.69889831542969 GB (111567.15234375 MB free)
+  Uptime: 143486.41 sec
+  Load Avg:  1.75  1.55  1.61
   WORD_SIZE: 64
   LIBM: libopenlibm
   LLVM: libLLVM-15.0.7 (ORCJIT, znver2)

--- a/perf.md
+++ b/perf.md
@@ -1,8 +1,8 @@
 # Benchmark Report for */home/vchuravy/src/ScopedVariables*
 
 ## Job Properties
-* Time of benchmark: 18 Aug 2023 - 11:32
-* Package commit: f51cd9
+* Time of benchmark: 18 Aug 2023 - 11:29
+* Package commit: dirty
 * Julia commit: 661654
 * Julia command flags: None
 * Environment variables: None
@@ -17,106 +17,106 @@ An empty cell means that the value was zero.
 
 | ID                                          | time            | GC time | memory         | allocations |
 |---------------------------------------------|----------------:|--------:|---------------:|------------:|
-| `["BASIC", "scoped with assignment & ref"]` |  93.355 ns (5%) |         | 208 bytes (1%) |           7 |
-| `["BASIC", "scoped with assignment"]`       |  88.448 ns (5%) |         | 208 bytes (1%) |           7 |
+| `["BASIC", "scoped with assignment & ref"]` | 107.314 ns (5%) |         | 112 bytes (1%) |           4 |
+| `["BASIC", "scoped with assignment"]`       |  66.095 ns (5%) |         | 112 bytes (1%) |           4 |
 | `["BASIC", "scoped"]`                       |   1.249 ns (5%) |         |                |             |
-| `["BASIC", "unscoped"]`                     |   4.380 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=1"]`              |   7.932 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=10"]`             |   6.508 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=11"]`             |   6.286 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=12"]`             |   6.298 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=13"]`             |   6.326 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=14"]`             |   6.581 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=15"]`             |   6.581 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=16"]`             |   6.667 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=17"]`             |   6.667 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=18"]`             |   6.682 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=19"]`             |   6.731 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=2"]`              |   6.347 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=20"]`             |   6.711 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=21"]`             |   6.745 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=22"]`             |   6.533 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=23"]`             |   6.717 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=24"]`             |   6.746 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=25"]`             |   6.531 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=26"]`             |   6.769 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=27"]`             |   6.782 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=28"]`             |   6.784 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=29"]`             |   6.786 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=3"]`              |   6.456 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=30"]`             |   6.811 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=31"]`             |   6.851 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=32"]`             |   6.893 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=4"]`              |   6.223 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=5"]`              |   6.467 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=6"]`              |   6.423 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=7"]`              |   6.478 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=8"]`              |   6.480 ns (5%) |         |                |             |
-| `["DEPTH", "access, depth=9"]`              |   6.481 ns (5%) |         |                |             |
-| `["DEPTH", "emtpyf, depth=1"]`              |  89.303 ns (5%) |         | 208 bytes (1%) |           7 |
-| `["DEPTH", "emtpyf, depth=10"]`             |   1.129 μs (5%) |         |  2.03 KiB (1%) |          70 |
-| `["DEPTH", "emtpyf, depth=11"]`             |   1.207 μs (5%) |         |  2.23 KiB (1%) |          77 |
-| `["DEPTH", "emtpyf, depth=12"]`             |   1.325 μs (5%) |         |  2.44 KiB (1%) |          84 |
-| `["DEPTH", "emtpyf, depth=13"]`             |   1.468 μs (5%) |         |  2.64 KiB (1%) |          91 |
-| `["DEPTH", "emtpyf, depth=14"]`             |   1.592 μs (5%) |         |  2.84 KiB (1%) |          98 |
-| `["DEPTH", "emtpyf, depth=15"]`             |   1.681 μs (5%) |         |  3.05 KiB (1%) |         105 |
-| `["DEPTH", "emtpyf, depth=16"]`             |   1.834 μs (5%) |         |  3.25 KiB (1%) |         112 |
-| `["DEPTH", "emtpyf, depth=17"]`             |   1.927 μs (5%) |         |  3.45 KiB (1%) |         119 |
-| `["DEPTH", "emtpyf, depth=18"]`             |   2.049 μs (5%) |         |  3.66 KiB (1%) |         126 |
-| `["DEPTH", "emtpyf, depth=19"]`             |   2.169 μs (5%) |         |  3.86 KiB (1%) |         133 |
-| `["DEPTH", "emtpyf, depth=2"]`              | 182.516 ns (5%) |         | 416 bytes (1%) |          14 |
-| `["DEPTH", "emtpyf, depth=20"]`             |   2.327 μs (5%) |         |  4.06 KiB (1%) |         140 |
-| `["DEPTH", "emtpyf, depth=21"]`             |   2.416 μs (5%) |         |  4.27 KiB (1%) |         147 |
-| `["DEPTH", "emtpyf, depth=22"]`             |   2.531 μs (5%) |         |  4.47 KiB (1%) |         154 |
-| `["DEPTH", "emtpyf, depth=23"]`             |   2.730 μs (5%) |         |  4.67 KiB (1%) |         161 |
-| `["DEPTH", "emtpyf, depth=24"]`             |   2.782 μs (5%) |         |  4.88 KiB (1%) |         168 |
-| `["DEPTH", "emtpyf, depth=25"]`             |   2.957 μs (5%) |         |  5.08 KiB (1%) |         175 |
-| `["DEPTH", "emtpyf, depth=26"]`             |   3.129 μs (5%) |         |  5.28 KiB (1%) |         182 |
-| `["DEPTH", "emtpyf, depth=27"]`             |   3.208 μs (5%) |         |  5.48 KiB (1%) |         189 |
-| `["DEPTH", "emtpyf, depth=28"]`             |   3.389 μs (5%) |         |  5.69 KiB (1%) |         196 |
-| `["DEPTH", "emtpyf, depth=29"]`             |   3.473 μs (5%) |         |  5.89 KiB (1%) |         203 |
-| `["DEPTH", "emtpyf, depth=3"]`              | 262.217 ns (5%) |         | 624 bytes (1%) |          21 |
-| `["DEPTH", "emtpyf, depth=30"]`             |   3.564 μs (5%) |         |  6.09 KiB (1%) |         210 |
-| `["DEPTH", "emtpyf, depth=31"]`             |   3.751 μs (5%) |         |  6.30 KiB (1%) |         217 |
-| `["DEPTH", "emtpyf, depth=32"]`             |   3.835 μs (5%) |         |  6.50 KiB (1%) |         224 |
-| `["DEPTH", "emtpyf, depth=4"]`              | 380.226 ns (5%) |         | 832 bytes (1%) |          28 |
-| `["DEPTH", "emtpyf, depth=5"]`              | 504.359 ns (5%) |         |  1.02 KiB (1%) |          35 |
-| `["DEPTH", "emtpyf, depth=6"]`              | 639.500 ns (5%) |         |  1.22 KiB (1%) |          42 |
-| `["DEPTH", "emtpyf, depth=7"]`              | 746.667 ns (5%) |         |  1.42 KiB (1%) |          49 |
-| `["DEPTH", "emtpyf, depth=8"]`              | 849.412 ns (5%) |         |  1.62 KiB (1%) |          56 |
-| `["DEPTH", "emtpyf, depth=9"]`              | 967.586 ns (5%) |         |  1.83 KiB (1%) |          63 |
-| `["DEPTH", "scope + access, depth=1"]`      | 110.714 ns (5%) |         | 240 bytes (1%) |           8 |
-| `["DEPTH", "scope + access, depth=10"]`     |   1.151 μs (5%) |         |  2.06 KiB (1%) |          71 |
-| `["DEPTH", "scope + access, depth=11"]`     |   1.308 μs (5%) |         |  2.27 KiB (1%) |          78 |
-| `["DEPTH", "scope + access, depth=12"]`     |   1.424 μs (5%) |         |  2.47 KiB (1%) |          85 |
-| `["DEPTH", "scope + access, depth=13"]`     |   1.538 μs (5%) |         |  2.67 KiB (1%) |          92 |
-| `["DEPTH", "scope + access, depth=14"]`     |   1.733 μs (5%) |         |  2.88 KiB (1%) |          99 |
-| `["DEPTH", "scope + access, depth=15"]`     |   1.869 μs (5%) |         |  3.08 KiB (1%) |         106 |
-| `["DEPTH", "scope + access, depth=16"]`     |   1.950 μs (5%) |         |  3.28 KiB (1%) |         113 |
-| `["DEPTH", "scope + access, depth=17"]`     |   2.056 μs (5%) |         |  3.48 KiB (1%) |         120 |
-| `["DEPTH", "scope + access, depth=18"]`     |   2.139 μs (5%) |         |  3.69 KiB (1%) |         127 |
-| `["DEPTH", "scope + access, depth=19"]`     |   2.368 μs (5%) |         |  3.89 KiB (1%) |         134 |
-| `["DEPTH", "scope + access, depth=2"]`      | 203.800 ns (5%) |         | 448 bytes (1%) |          15 |
-| `["DEPTH", "scope + access, depth=20"]`     |   2.444 μs (5%) |         |  4.09 KiB (1%) |         141 |
-| `["DEPTH", "scope + access, depth=21"]`     |   2.689 μs (5%) |         |  4.30 KiB (1%) |         148 |
-| `["DEPTH", "scope + access, depth=22"]`     |   2.772 μs (5%) |         |  4.50 KiB (1%) |         155 |
-| `["DEPTH", "scope + access, depth=23"]`     |   2.896 μs (5%) |         |  4.70 KiB (1%) |         162 |
-| `["DEPTH", "scope + access, depth=24"]`     |   3.064 μs (5%) |         |  4.91 KiB (1%) |         169 |
-| `["DEPTH", "scope + access, depth=25"]`     |   3.141 μs (5%) |         |  5.11 KiB (1%) |         176 |
-| `["DEPTH", "scope + access, depth=26"]`     |   3.170 μs (5%) |         |  5.31 KiB (1%) |         183 |
-| `["DEPTH", "scope + access, depth=27"]`     |   3.413 μs (5%) |         |  5.52 KiB (1%) |         190 |
-| `["DEPTH", "scope + access, depth=28"]`     |   3.573 μs (5%) |         |  5.72 KiB (1%) |         197 |
-| `["DEPTH", "scope + access, depth=29"]`     |   3.706 μs (5%) |         |  5.92 KiB (1%) |         204 |
-| `["DEPTH", "scope + access, depth=3"]`      | 282.892 ns (5%) |         | 656 bytes (1%) |          22 |
-| `["DEPTH", "scope + access, depth=30"]`     |   3.719 μs (5%) |         |  6.12 KiB (1%) |         211 |
-| `["DEPTH", "scope + access, depth=31"]`     |   3.834 μs (5%) |         |  6.33 KiB (1%) |         218 |
-| `["DEPTH", "scope + access, depth=32"]`     |   4.044 μs (5%) |         |  6.53 KiB (1%) |         225 |
-| `["DEPTH", "scope + access, depth=4"]`      | 454.451 ns (5%) |         | 864 bytes (1%) |          29 |
-| `["DEPTH", "scope + access, depth=5"]`      | 569.000 ns (5%) |         |  1.05 KiB (1%) |          36 |
-| `["DEPTH", "scope + access, depth=6"]`      | 653.000 ns (5%) |         |  1.25 KiB (1%) |          43 |
-| `["DEPTH", "scope + access, depth=7"]`      | 779.000 ns (5%) |         |  1.45 KiB (1%) |          50 |
-| `["DEPTH", "scope + access, depth=8"]`      | 924.000 ns (5%) |         |  1.66 KiB (1%) |          57 |
-| `["DEPTH", "scope + access, depth=9"]`      |   1.072 μs (5%) |         |  1.86 KiB (1%) |          64 |
+| `["BASIC", "unscoped"]`                     | 341.560 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=1"]`              |  22.269 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=10"]`             | 198.036 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=11"]`             | 213.926 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=12"]`             | 231.682 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=13"]`             | 249.751 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=14"]`             | 267.796 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=15"]`             | 288.529 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=16"]`             | 304.297 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=17"]`             | 324.035 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=18"]`             | 341.659 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=19"]`             | 362.596 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=2"]`              |  41.937 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=20"]`             | 379.412 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=21"]`             | 397.500 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=22"]`             | 416.533 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=23"]`             | 435.000 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=24"]`             | 451.726 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=25"]`             | 473.214 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=26"]`             | 490.821 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=27"]`             | 507.979 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=28"]`             | 538.737 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=29"]`             | 547.540 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=3"]`              |  61.059 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=30"]`             | 564.486 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=31"]`             | 582.762 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=32"]`             | 601.243 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=4"]`              |  87.024 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=5"]`              | 104.568 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=6"]`              | 121.517 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=7"]`              | 141.802 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=8"]`              | 159.298 ns (5%) |         |                |             |
+| `["DEPTH", "access, depth=9"]`              | 177.915 ns (5%) |         |                |             |
+| `["DEPTH", "emtpyf, depth=1"]`              |  88.855 ns (5%) |         | 128 bytes (1%) |           5 |
+| `["DEPTH", "emtpyf, depth=10"]`             | 935.000 ns (5%) |         |  1.25 KiB (1%) |          50 |
+| `["DEPTH", "emtpyf, depth=11"]`             |   1.104 μs (5%) |         |  1.38 KiB (1%) |          55 |
+| `["DEPTH", "emtpyf, depth=12"]`             |   1.180 μs (5%) |         |  1.50 KiB (1%) |          60 |
+| `["DEPTH", "emtpyf, depth=13"]`             |   1.278 μs (5%) |         |  1.62 KiB (1%) |          65 |
+| `["DEPTH", "emtpyf, depth=14"]`             |   1.364 μs (5%) |         |  1.75 KiB (1%) |          70 |
+| `["DEPTH", "emtpyf, depth=15"]`             |   1.509 μs (5%) |         |  1.88 KiB (1%) |          75 |
+| `["DEPTH", "emtpyf, depth=16"]`             |   1.561 μs (5%) |         |  2.00 KiB (1%) |          80 |
+| `["DEPTH", "emtpyf, depth=17"]`             |   1.715 μs (5%) |         |  2.12 KiB (1%) |          85 |
+| `["DEPTH", "emtpyf, depth=18"]`             |   1.844 μs (5%) |         |  2.25 KiB (1%) |          90 |
+| `["DEPTH", "emtpyf, depth=19"]`             |   1.987 μs (5%) |         |  2.38 KiB (1%) |          95 |
+| `["DEPTH", "emtpyf, depth=2"]`              | 160.050 ns (5%) |         | 256 bytes (1%) |          10 |
+| `["DEPTH", "emtpyf, depth=20"]`             |   2.001 μs (5%) |         |  2.50 KiB (1%) |         100 |
+| `["DEPTH", "emtpyf, depth=21"]`             |   2.172 μs (5%) |         |  2.62 KiB (1%) |         105 |
+| `["DEPTH", "emtpyf, depth=22"]`             |   2.259 μs (5%) |         |  2.75 KiB (1%) |         110 |
+| `["DEPTH", "emtpyf, depth=23"]`             |   2.257 μs (5%) |         |  2.88 KiB (1%) |         115 |
+| `["DEPTH", "emtpyf, depth=24"]`             |   2.474 μs (5%) |         |  3.00 KiB (1%) |         120 |
+| `["DEPTH", "emtpyf, depth=25"]`             |   2.629 μs (5%) |         |  3.12 KiB (1%) |         125 |
+| `["DEPTH", "emtpyf, depth=26"]`             |   2.668 μs (5%) |         |  3.25 KiB (1%) |         130 |
+| `["DEPTH", "emtpyf, depth=27"]`             |   2.842 μs (5%) |         |  3.38 KiB (1%) |         135 |
+| `["DEPTH", "emtpyf, depth=28"]`             |   2.942 μs (5%) |         |  3.50 KiB (1%) |         140 |
+| `["DEPTH", "emtpyf, depth=29"]`             |   3.269 μs (5%) |         |  3.62 KiB (1%) |         145 |
+| `["DEPTH", "emtpyf, depth=3"]`              | 230.896 ns (5%) |         | 384 bytes (1%) |          15 |
+| `["DEPTH", "emtpyf, depth=30"]`             |   3.123 μs (5%) |         |  3.75 KiB (1%) |         150 |
+| `["DEPTH", "emtpyf, depth=31"]`             |   3.251 μs (5%) |         |  3.88 KiB (1%) |         155 |
+| `["DEPTH", "emtpyf, depth=32"]`             |   3.665 μs (5%) |         |  4.00 KiB (1%) |         160 |
+| `["DEPTH", "emtpyf, depth=4"]`              | 366.425 ns (5%) |         | 512 bytes (1%) |          20 |
+| `["DEPTH", "emtpyf, depth=5"]`              | 442.615 ns (5%) |         | 640 bytes (1%) |          25 |
+| `["DEPTH", "emtpyf, depth=6"]`              | 530.778 ns (5%) |         | 768 bytes (1%) |          30 |
+| `["DEPTH", "emtpyf, depth=7"]`              | 669.887 ns (5%) |         | 896 bytes (1%) |          35 |
+| `["DEPTH", "emtpyf, depth=8"]`              | 760.588 ns (5%) |         |  1.00 KiB (1%) |          40 |
+| `["DEPTH", "emtpyf, depth=9"]`              | 858.276 ns (5%) |         |  1.12 KiB (1%) |          45 |
+| `["DEPTH", "scope + access, depth=1"]`      | 681.169 ns (5%) |         | 128 bytes (1%) |           5 |
+| `["DEPTH", "scope + access, depth=10"]`     |   1.375 μs (5%) |         |  1.25 KiB (1%) |          50 |
+| `["DEPTH", "scope + access, depth=11"]`     |   2.000 μs (5%) |         |  1.38 KiB (1%) |          55 |
+| `["DEPTH", "scope + access, depth=12"]`     |   1.962 μs (5%) |         |  1.50 KiB (1%) |          60 |
+| `["DEPTH", "scope + access, depth=13"]`     |   1.865 μs (5%) |         |  1.62 KiB (1%) |          65 |
+| `["DEPTH", "scope + access, depth=14"]`     |   2.313 μs (5%) |         |  1.75 KiB (1%) |          70 |
+| `["DEPTH", "scope + access, depth=15"]`     |   2.004 μs (5%) |         |  1.88 KiB (1%) |          75 |
+| `["DEPTH", "scope + access, depth=16"]`     |   2.449 μs (5%) |         |  2.00 KiB (1%) |          80 |
+| `["DEPTH", "scope + access, depth=17"]`     |   2.437 μs (5%) |         |  2.12 KiB (1%) |          85 |
+| `["DEPTH", "scope + access, depth=18"]`     |   2.461 μs (5%) |         |  2.25 KiB (1%) |          90 |
+| `["DEPTH", "scope + access, depth=19"]`     |   2.944 μs (5%) |         |  2.38 KiB (1%) |          95 |
+| `["DEPTH", "scope + access, depth=2"]`      | 413.950 ns (5%) |         | 256 bytes (1%) |          10 |
+| `["DEPTH", "scope + access, depth=20"]`     |   2.907 μs (5%) |         |  2.50 KiB (1%) |         100 |
+| `["DEPTH", "scope + access, depth=21"]`     |   3.236 μs (5%) |         |  2.62 KiB (1%) |         105 |
+| `["DEPTH", "scope + access, depth=22"]`     |   2.902 μs (5%) |         |  2.75 KiB (1%) |         110 |
+| `["DEPTH", "scope + access, depth=23"]`     |   3.200 μs (5%) |         |  2.88 KiB (1%) |         115 |
+| `["DEPTH", "scope + access, depth=24"]`     |   3.261 μs (5%) |         |  3.00 KiB (1%) |         120 |
+| `["DEPTH", "scope + access, depth=25"]`     |   3.382 μs (5%) |         |  3.12 KiB (1%) |         125 |
+| `["DEPTH", "scope + access, depth=26"]`     |   3.799 μs (5%) |         |  3.25 KiB (1%) |         130 |
+| `["DEPTH", "scope + access, depth=27"]`     |   3.989 μs (5%) |         |  3.38 KiB (1%) |         135 |
+| `["DEPTH", "scope + access, depth=28"]`     |   4.524 μs (5%) |         |  3.50 KiB (1%) |         140 |
+| `["DEPTH", "scope + access, depth=29"]`     |   4.399 μs (5%) |         |  3.62 KiB (1%) |         145 |
+| `["DEPTH", "scope + access, depth=3"]`      | 823.976 ns (5%) |         | 384 bytes (1%) |          15 |
+| `["DEPTH", "scope + access, depth=30"]`     |   4.330 μs (5%) |         |  3.75 KiB (1%) |         150 |
+| `["DEPTH", "scope + access, depth=31"]`     |   4.294 μs (5%) |         |  3.88 KiB (1%) |         155 |
+| `["DEPTH", "scope + access, depth=32"]`     |   4.607 μs (5%) |         |  4.00 KiB (1%) |         160 |
+| `["DEPTH", "scope + access, depth=4"]`      | 625.183 ns (5%) |         | 512 bytes (1%) |          20 |
+| `["DEPTH", "scope + access, depth=5"]`      |   1.180 μs (5%) |         | 640 bytes (1%) |          25 |
+| `["DEPTH", "scope + access, depth=6"]`      |   1.292 μs (5%) |         | 768 bytes (1%) |          30 |
+| `["DEPTH", "scope + access, depth=7"]`      |   1.303 μs (5%) |         | 896 bytes (1%) |          35 |
+| `["DEPTH", "scope + access, depth=8"]`      |   1.198 μs (5%) |         |  1.00 KiB (1%) |          40 |
+| `["DEPTH", "scope + access, depth=9"]`      |   1.278 μs (5%) |         |  1.12 KiB (1%) |          45 |
 
 ## Benchmark Group List
 Here's a list of all the benchmark groups executed by this job:
@@ -134,10 +134,10 @@ Platform Info:
   uname: Linux 6.3.2-arch1-1 #1 SMP PREEMPT_DYNAMIC Thu, 11 May 2023 16:40:42 +0000 x86_64 unknown
   CPU: AMD Ryzen 7 3700X 8-Core Processor: 
                  speed         user         nice          sys         idle          irq
-       #1-16  4050 MHz    1085082 s        282 s      41546 s   20897081 s       9707 s
-  Memory: 125.69889831542969 GB (111144.1171875 MB free)
-  Uptime: 142694.21 sec
-  Load Avg:  1.85  1.86  1.72
+       #1-16  4051 MHz    1082294 s        282 s      41334 s   20869973 s       9692 s
+  Memory: 125.69889831542969 GB (111007.203125 MB free)
+  Uptime: 142505.67 sec
+  Load Avg:  2.18  1.97  1.71
   WORD_SIZE: 64
   LIBM: libopenlibm
   LLVM: libLLVM-15.0.7 (ORCJIT, znver2)

--- a/src/ScopedValues.jl
+++ b/src/ScopedValues.jl
@@ -36,41 +36,32 @@ mutable struct ScopedValue{T}
     ScopedValue{T}(initial_value) where {T} = new{T}(initial_value)
 end
 ScopedValue(initial_value::T) where {T} = ScopedValue{T}(initial_value)
-# Base.hash(var::ScopedValue) = Base.objectid(var)
-# Base.isequal(a::ScopedValue, b::ScopedValue) = Base.objectid(a) == Base.objectid(b)
 
 Base.eltype(::Type{ScopedValue{T}}) where {T} = T
 
-# Split Scope and ScopeCache into two separate entities
-# Scope is read-only after construction, and ScopeCache is task-local
-# thus we are lock-free.
-
-import Base: ImmutableDict
-
-mutable struct Scope
-    const values::ImmutableDict{ScopedValue, Any}
+# If we wanted to be really fancy we could implement Scope,
+# as Ctrie
+mutable struct Scope{T}
+    const parent::Union{Nothing, Scope}
+    const key::ScopedValue{T}
+    const value::T
 end
-Scope() = new(ImmutableDict{ScopedValue, Any}())
+Scope(parent, key::ScopedValue{T}, value) where T =
+    Scope(parent, key, convert(T, value))
 
 function Base.show(io::IO, ::Scope)
     print(io, Scope)
 end
 
-@inline function _get(dict::ImmutableDict, key, ::Type{T}) where T
-    while isdefined(dict, :parent)
-        isequal(dict.key, key) && return Some(dict.value::T)
-        dict = dict.parent
-    end
-    return nothing
-end
-
 function Base.getindex(var::ScopedValue{T})::T where T
     scope = current_scope()
-    if scope === nothing
-        return var.initial_value
+    while scope !== nothing
+        if scope.key === var
+            return scope.value::T
+        end
+        scope = scope.parent
     end
-
-    return something(_get(scope.values, var, T), var.initial_value)
+    return var.initial_value
 end
 
 function Base.show(io::IO, var::ScopedValue)
@@ -88,15 +79,11 @@ Execute `f` in a new scope with `var` set to `val`.
 """
 function scoped(f, pair::Pair{<:ScopedValue}, rest::Pair{<:ScopedValue}...)
     scope = current_scope()
-    if scope === nothing
-        values = ImmutableDict{ScopedValue, Any}(pair...)
-    else
-        values = ImmutableDict{ScopedValue, Any}(scope.values, pair...)
-    end
+    scope = Scope(scope, pair...)
     for pair in rest
-        values = ImmutableDict{ScopedValue, Any}(values, pair...)
+        scope = Scope(scope, pair...)
     end
-    enter_scope(Scope(values)) do
+    enter_scope(scope) do
         f()
     end
 end

--- a/src/ScopedValues.jl
+++ b/src/ScopedValues.jl
@@ -41,10 +41,11 @@ Base.eltype(::Type{ScopedValue{T}}) where {T} = T
 
 # If we wanted to be really fancy we could implement Scope,
 # as Ctrie
-mutable struct Scope{T}
+mutable struct Scope
     const parent::Union{Nothing, Scope}
-    const key::ScopedValue{T}
-    const value::T
+    const key::ScopedValue
+    const value::Any
+    Scope(parent, key::ScopedValue{T}, value::T) where T = new(parent, key, value)
 end
 Scope(parent, key::ScopedValue{T}, value) where T =
     Scope(parent, key, convert(T, value))

--- a/src/payloadlogger.jl
+++ b/src/payloadlogger.jl
@@ -13,8 +13,8 @@ function current_scope()
     return nothing
 end
 
-function enter_scope(f)
-    return Logging.with_logger(f, ScopePayloadLogger(current_logger(), Scope(current_scope())))
+function enter_scope(f, scope)
+    return Logging.with_logger(f, ScopePayloadLogger(current_logger(), scope))
 end
 
 # Forward actual logging interface:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -34,6 +34,13 @@ const gvar_float = ScopedValue(1.0)
     end
 end
 
+emptyf() = nothing
+
+@testset "conversion" begin
+    scoped(emptyf, gvar_float=>2)
+    @test_throws MethodError scoped(emptyf, gvar_float=>"hello")
+end
+
 import Base.Threads: @spawn
 @testset "tasks" begin
     @test fetch(@spawn begin


### PR DESCRIPTION
ImmutableDict is essentially a linked list of key, value pairs.

In the previous design scopes formed a linked list, each element
containing a ImmutableDict. We would search the list of scopes
and within the list of scopes the ImmutableDict. Then copy the value
into the current scope to short-circuit the search.

This PR gives up the short-circuiting, but removes the linked list nature of scopes
and instead collapses it all into the immutable dict.

