### PR TITLE
add `@with`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScopedValues"
 uuid = "7e506255-f358-4e82-b7e4-beb19740aa63"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "1.1.0"
+version = "1.2.0"
 
 [deps]
 HashArrayMappedTries = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"

--- a/src/payloadlogger.jl
+++ b/src/payloadlogger.jl
@@ -2,7 +2,7 @@ using Logging: AbstractLogger, Logging
 
 struct ScopePayloadLogger <: AbstractLogger
     logger::AbstractLogger
-    scope::Scope
+    scope::Union{Scope, Nothing}
 end
 
 function current_scope()

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -73,7 +73,8 @@ end
     with(sval => 2.0) do
         @test sprint(show, sval) == "ScopedValue{$Int}(2)"
         objid = sprint(show, Base.objectid(sval))
-        @test sprint(show, ScopedValues.current_scope()) == "ScopedValues.Scope(ScopedValue{$Int}@$objid => 2)"
+        # Interpolate to handle `Base.ScopedValues.Scope` vs `ScopedValues.scope`
+        @test sprint(show, ScopedValues.current_scope()) == "$(ScopedValues.Scope)(ScopedValue{$Int}@$objid => 2)"
     end
 end
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -114,3 +114,17 @@ end
         end
     end
 end
+
+@testset "macro" begin
+    @with sval=>2 sval_float=>2.0 begin
+        @test sval[] == 2
+        @test sval_float[] == 2.0
+    end
+    # Doesn't do much...
+    ret = @with begin
+        @test sval[] == 1
+        @test sval_float[] == 1.0
+        1.23 # return value
+    end
+    @test ret == 1.23
+end


### PR DESCRIPTION
Matches the API in Base, but implemented with a sequence of nested macros 😓. Seems to work though.

Would like to use this to simplify stacktraces (rather than a layer of scoped stuff every time) by getting rid of these four frames:
```julia
    [5] with_logstate(f::Function, logstate::Any)
      @ Base.CoreLogging ./logging.jl:514
    [6] with_logger
      @ ./logging.jl:626 [inlined]
    [7] enter_scope
      @ ~/.julia/packages/ScopedValues/92HJZ/src/payloadlogger.jl:17 [inlined]
    [8] with(::Any, ::Pair{<:ScopedValues.ScopedValue})
      @ ScopedValues ~/.julia/packages/ScopedValues/92HJZ/src/ScopedValues.jl:162
```