### PR TITLE
Don't specialize Logging.handle_message

### DIFF
--- a/src/payloadlogger.jl
+++ b/src/payloadlogger.jl
@@ -18,8 +18,10 @@ function enter_scope(f, scope)
 end
 
 # Forward actual logging interface:
-Logging.handle_message(payload::ScopePayloadLogger, args...; kwargs...) =
-    Logging.handle_message(payload.logger, args...; kwargs...)
+function Logging.handle_message(payload::ScopePayloadLogger, args...; kwargs...)
+    @nospecialize
+    return Logging.handle_message(payload.logger, args...; kwargs...)
+end
 Logging.shouldlog(payload::ScopePayloadLogger, args...) =
     Logging.shouldlog(payload.logger, args...)
 Logging.min_enabled_level(payload::ScopePayloadLogger, args...) =


### PR DESCRIPTION
Similarly to the Julia implementation of [Logging.handle_message(::ConsoleLogger, ...)](https://github.com/RelationalAI/julia/blob/061a13904da9fb875458687739dead87b4919d30/stdlib/Logging/src/ConsoleLogger.jl#L108), the PR avoids specializing `handle_message` for the different combinations of arguments.