### PR TITLE
Rename `ScopedFunctor` -> `ScopedThunk` (per upstream)

### DIFF
--- a/src/ScopedValues.jl
+++ b/src/ScopedValues.jl
@@ -239,8 +239,8 @@ end # isdefined
 """
     ScopedThunk(f)
 
-Create a functor that records the current dynamic scope, i.e. all current
-`ScopedValue`s, along with `f`. When the functor is invoked, it runs `f`
+Create a callable that records the current dynamic scope, i.e. all current
+`ScopedValue`s, along with `f`. When the callable is invoked, it runs `f`
 in the recorded dynamic scope.
 """
 struct ScopedThunk{F}

--- a/src/ScopedValues.jl
+++ b/src/ScopedValues.jl
@@ -1,6 +1,6 @@
 module ScopedValues
 
-export ScopedValue, with, @with, ScopedFunctor
+export ScopedValue, with, @with, ScopedThunk
 
 if isdefined(Base, :ScopedValues)
 
@@ -237,21 +237,22 @@ include("payloadlogger.jl")
 end # isdefined
 
 """
-    ScopedFunctor(f)
+    ScopedThunk(f)
 
 Create a functor that records the current dynamic scope, i.e. all current
 `ScopedValue`s, along with `f`. When the functor is invoked, it runs `f`
 in the recorded dynamic scope.
 """
-struct ScopedFunctor{F}
+struct ScopedThunk{F}
     f::F
     scope::Union{Nothing, Scope}
 
-    ScopedFunctor{F}(f) where {F} = new{F}(f, current_scope())
+    ScopedThunk{F}(f) where {F} = new{F}(f, current_scope())
 end
-ScopedFunctor(f) = ScopedFunctor{typeof(f)}(f)
-(sf::ScopedFunctor)() = @enter_scope sf.scope sf.f()
+ScopedThunk(f) = ScopedThunk{typeof(f)}(f)
+(sf::ScopedThunk)() = @enter_scope sf.scope sf.f()
 
 @deprecate scoped with
+@deprecate ScopedFunctor ScopedThunk
 
 end # module ScopedValues

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -130,18 +130,18 @@ end
     @test ret == 1.23
 end
 
-@testset "ScopedFunctor" begin
+@testset "ScopedThunk" begin
     function check_svals()
         @test sval[] == 8
         @test sval_float[] == 8.0
     end
     sf = nothing
     @with sval=>8 sval_float=>8.0 begin
-        sf = ScopedFunctor(check_svals)
+        sf = ScopedThunk(check_svals)
     end
     sf()
     @with sval=>8 sval_float=>8.0 begin
-        sf2 = ScopedFunctor{Function}(check_svals)
+        sf2 = ScopedThunk{Function}(check_svals)
     end
     sf2()
 end


### PR DESCRIPTION
When this got ported upstream (https://github.com/JuliaLang/julia/pull/59402), consensus was to rename it, so let's make sure we're consistent

deprecates the old name to avoid being a breaking change

cc @kpamnany 