### PR TITLE
Change `isassigned()` to match the Base definition

### DIFF
--- a/src/ScopedValues.jl
+++ b/src/ScopedValues.jl
@@ -66,9 +66,14 @@ Base.eltype(::ScopedValue{T}) where {T} = T
 """
     isassigned(val::ScopedValue)
 
-Test if the ScopedValue has a default value.
+Test if the ScopedValue has an assigned value.
 """
-Base.isassigned(val::ScopedValue) = val.has_default
+function Base.isassigned(val::ScopedValue)
+    val.has_default && return true
+    scope = current_scope()::Union{Scope, Nothing}
+    scope === nothing && return false
+    return haskey((scope::Scope).values, val)
+end
 
 const ScopeStorage = HAMT{ScopedValue, Any}
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -131,6 +131,13 @@ end
     @test ret == 1.23
 end
 
+const sval_uninitialized = ScopedValue{Int}()
+
+@testset "isassigned()" begin
+    @test !isassigned(sval_uninitialized)
+    @with sval_uninitialized => 42 @test isassigned(sval_uninitialized)
+end
+
 @testset "ScopedThunk" begin
     function check_svals()
         @test sval[] == 8


### PR DESCRIPTION
ScopedValues.jl previously used `isassigned()` to check if a `ScopedValue` had a default value, but that differs from Base which uses `isassigned()` to check if a `ScopedValue` is initialized in the current scope.

Fixes this behaviour:
```julia-repl
julia> using ScopedValues

julia> x = ScopedValue{Int}()
ScopedValue{Int64}(undefined)

julia> isassigned(x)
false

# On 1.11+ this returns true
julia> @with x => 1 isassigned(x)
false
```

This is technically a breaking change, but I would consider it a bugfix to match Base. It came up in the wild when using ScopedValues.jl in DistributedNext (https://github.com/JuliaParallel/DistributedNext.jl/pull/17).