### PR TITLE
Fix UndefRefError in `get` for abstract-typed ScopedValue (#34)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "ScopedValues"
 uuid = "7e506255-f358-4e82-b7e4-beb19740aa63"
 authors = ["Valentin Churavy <v.churavy@gmail.com>"]
-version = "1.6.1"
+version = "1.6.2"
 
 [deps]
 HashArrayMappedTries = "076d061b-32b6-4027-95e0-9a2c6f6d7e74"

--- a/src/ScopedValues.jl
+++ b/src/ScopedValues.jl
@@ -128,18 +128,18 @@ return `nothing`. Otherwise returns `Some{T}` with the current
 value.
 """
 function get(val::ScopedValue{T}) where {T}
-    # Inline current_scope to avoid doing the type assertion twice.
     scope = current_scope()
     if scope === nothing
-        isassigned(val) && return Some(val.default)
-        return nothing
+        val.has_default || return nothing
+        return Some{T}(val.default)
     end
     scope = scope::Scope
-    if isassigned(val)
-        return Some(Base.get(scope.values, val, val.default)::T)
+    if val.has_default
+        return Some{T}(Base.get(scope.values, val, val.default)::T)
     else
         v = Base.get(scope.values, val, novalue)
-        v === novalue || return Some(v::T)
+        v === novalue && return nothing
+        return Some{T}(v::T)
     end
     return nothing
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -138,6 +138,23 @@ const sval_uninitialized = ScopedValue{Int}()
     @with sval_uninitialized => 42 @test isassigned(sval_uninitialized)
 end
 
+@testset "abstract type" begin
+    # Regression test for issue #34: ScopedValue with abstract type parameter
+    abstract_val = ScopedValue{Integer}()
+    @test ScopedValues.get(abstract_val) === nothing
+    @with abstract_val => 3 begin
+        @test ScopedValues.get(abstract_val) == Some{Integer}(3)
+        @test abstract_val[] == 3
+    end
+    @test ScopedValues.get(abstract_val) === nothing
+
+    abstract_with_default = ScopedValue{Integer}(42)
+    @test ScopedValues.get(abstract_with_default) == Some{Integer}(42)
+    @with abstract_with_default => 3 begin
+        @test ScopedValues.get(abstract_with_default) == Some{Integer}(3)
+    end
+end
+
 @testset "ScopedThunk" begin
     function check_svals()
         @test sval[] == 8


### PR DESCRIPTION
- **Fix UndefRefError in `get` for abstract-typed ScopedValue (#34)**
- **Bump version from 1.6.1 to 1.6.2**

Code reviewed manually by me, adopted from current Base by Claude.
